### PR TITLE
Removing details of T-drive connection

### DIFF
--- a/content/docs/computers-and-programming/t-drive.md
+++ b/content/docs/computers-and-programming/t-drive.md
@@ -3,19 +3,11 @@ title: "Accessing the T-drive"
 summary: " "
 ---
 
-If off campus, turn on the virtual private network (VPN) before connecting using the instructions here: https://vpn.ufl.edu/
-
-## Windows
-
-* Follow the instructions here: https://wec.ifas.ufl.edu/resources/it--computer-support/mapping-your-t-and-u-drives/
-
-## Mac
-
-* Open the Finder, and from the menu bar select **Go > Connect to Server**.
-* Enter `smb://ad.ufl.edu/ifas/wec/groups/` as the "server address.
-* If you'd like to keep this URL stored as a "favorite", click the `+` next to the address bar
-* Click "Connect"
-* Lab materials are in the `lab-white-ernest` folder.
+* If off campus, turn on the virtual private network (VPN) before connecting using the instructions here: https://vpn.ufl.edu/
+* Follow the instructions for: 1) [Windows](https://wec.ifas.ufl.edu/resources/it--computer-support/mapping-your-t-and-u-drives/) or 2) [macOS](https://wec.ifas.ufl.edu/resources/it--computer-support/mapping-your-t-and-u-drives-mac/)
+* On Linux use the same basic approach described in the Windows/macOS instructions, but enter `UFAD` for the `WORKGROUP`
+* Lab materials are in the `lab-white-ernest` folder
+* Our public file serving folder is `Weecology`
 
 ## Linux
 
@@ -23,5 +15,6 @@ Assuming you're running Ubuntu. Install the cifs-utils package, create a folder 
 
     sudo apt-get install cifs-utils
     sudo mkdir /media/T
-    sudo mount -t cifs //ict-az2-fs11.server.ufl.edu/ifas-wec/groups/ /media/T/ -o username=<your-gatorlink>
+    sudo mount -t cifs LINK_FROM_INSTRUCTIONS_ABOVE_WITHOUT_SMB_PART /media/T/ -o username=<your-gatorlink>
     
+(Yes, it would be nice if the LINK_FROM_INSTRUCTIONS_ABOVE_WITHOUT_SMB_PART could be provided directly, but apparently UFIT is a 'security through obscurity' shop ¯\_(ツ)_/¯).


### PR DESCRIPTION
UFIT asked us to remove the addresses for the T-drive connections.
Because apparently cycling passwords isn't the only security approach
here that violates NIST standards.
